### PR TITLE
Implement static site url shortener

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,4 +4,56 @@ permalink: /404.html
 sitemap: false
 ---
 
+<script>
+(function () {
+  try {
+    var base = '{{ site.baseurl | default: "" }}';
+    var path = window.location.pathname || '/';
+    if (base && path.indexOf(base) === 0) {
+      path = path.slice(base.length) || '/';
+    }
+
+    // Handle shortlinks at /s/<slug>
+    if (path.indexOf('/s/') !== 0) {
+      return;
+    }
+
+    var slug = path.substring(3).replace(/^\/+|\/+$/g, '');
+    if (!slug) return;
+
+    // Embed YAML data from _data/shortlinks.yml directly as a JS object
+    var linkMap = {{ site.data.shortlinks | default: {} | jsonify }};
+
+    var target = linkMap && linkMap[slug];
+    if (!target && slug.indexOf('/') !== -1) {
+      // Optionally fall back to the first path segment
+      var first = slug.split('/')[0];
+      target = linkMap[first];
+    }
+
+    if (typeof target === 'string' && target.length > 0) {
+      var isAbsolute = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target);
+      var url = target;
+      if (!isAbsolute) {
+        if (target.charAt(0) !== '/') target = '/' + target;
+        url = (base || '') + target;
+      }
+
+      // Replace without adding to history; provide a clickable fallback
+      window.location.replace(url);
+      var p = document.createElement('p');
+      var a = document.createElement('a');
+      a.href = url;
+      a.textContent = 'Click here if you are not redirected.';
+      p.appendChild(a);
+      document.addEventListener('DOMContentLoaded', function () {
+        document.body.appendChild(p);
+      });
+    }
+  } catch (e) {
+    // Intentionally no-op on errors; fall back to normal 404 content
+  }
+})();
+</script>
+
 <h1>This page could not be found</h1>

--- a/404.html
+++ b/404.html
@@ -21,8 +21,8 @@ sitemap: false
     var slug = path.substring(3).replace(/^\/+|\/+$/g, '');
     if (!slug) return;
 
-    // Embed YAML data from _data/shortlinks.yml directly as a JS object
-    var linkMap = {{ site.data.shortlinks | default: {} | jsonify }};
+    // Embed YAML data from _data/shortlinks.yml; fall back to {}
+    var linkMap = {{ site.data.shortlinks | jsonify }} || {};
 
     var target = linkMap && linkMap[slug];
     if (!target && slug.indexOf('/') !== -1) {

--- a/_data/shortlinks.yml
+++ b/_data/shortlinks.yml
@@ -1,0 +1,8 @@
+# Slug -> URL mapping for shortlinks used by the 404 router.
+# Keys are the slugs under /s/<slug>. Values can be:
+# - An absolute URL (e.g., https://example.com/path)
+# - A site-relative path (e.g., /recipes.html)
+#
+# Examples (uncomment and adjust):
+# docs: /recipes.html
+# repo: https://github.com/your/repo


### PR DESCRIPTION
Implement a client-side URL shortener via `404.html` and `_data/shortlinks.yml` for non-discoverable shortlinks without extra infrastructure.

---
<a href="https://cursor.com/background-agent?bcId=bc-fba3b64d-19a2-4ac4-8786-05f96da80e53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fba3b64d-19a2-4ac4-8786-05f96da80e53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

